### PR TITLE
Add support for icondarkfile for TournamentMenu

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -59,6 +59,11 @@ class Data {
 									$iconfile = htmlspecialchars( trim( explode( '=', $value )[ 1 ] ) );
 								}
 								unset( $line[ $key ] );
+							} elseif ( strpos( $value, 'icondarkfile' ) === 0 ) {
+								if ( !empty( trim( explode( '=', $value )[ 1 ] ) ) ) {
+									$icondarkfile = htmlspecialchars( trim( explode( '=', $value )[ 1 ] ) );
+								}
+								unset( $line[ $key ] );
 							} elseif ( strpos( $value, 'icon' ) === 0 ) {
 								if ( !empty( trim( explode( '=', $value )[ 1 ] ) ) ) {
 									$icon = htmlspecialchars( trim( explode( '=', $value )[ 1 ] ) );
@@ -131,10 +136,13 @@ class Data {
 						if ( isset( $iconfile ) ) {
 							$data[ 'iconfile' ] = $iconfile;
 						}
+						if ( isset( $icondarkfile ) ) {
+							$data[ 'icondarkfile' ] = $icondarkfile;
+						}
 						if ( isset( $filter ) ) {
 							$data[ 'filter' ] = $filter;
 						}
-						unset( $startDate, $endDate, $icon, $iconfile, $filter );
+						unset( $startDate, $endDate, $icon, $iconfile, $icondarkfile, $filter );
 
 						$tournamentData[ $heading ][] = $data;
 					} else {

--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -56,7 +56,8 @@ class MainHookHandler implements
 						];
 
 						// Should we add an icon
-						// icon = SMW.Is part of series; iconfile = SMW.Has icon
+						// icon = SMW.Is part of series or LPDB.series
+						// iconfile = SMW.Has icon or LPDB.icon
 						if ( array_key_exists( 'icon', $tournament ) ) {
 							$iconTitle = Title::newFromText(
 									$iconTemplatePrefix . '/' . $tournament[ 'icon' ],

--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -87,7 +87,8 @@ class MainHookHandler implements
 								if ( !$commandLineMode ) {
 									$iconHTML = $out->parseInlineAsInterface(
 										'{{' . $iconTemplatePrefix . '/mainpageTST|' .
-										$tournament[ 'iconfile' ] . '|link=}}',
+										'iconDark=' . $tournament[ 'icondarkfile' ] .
+										'|' . $tournament[ 'iconfile' ] . '|link=}}',
 										false
 									);
 									if ( strpos( $iconHTML, 'mw-parser-output' ) !== false ) {

--- a/src/ParserFunction.php
+++ b/src/ParserFunction.php
@@ -61,7 +61,8 @@ class ParserFunction {
 					$return .= '<span class="tournaments-list-name">';
 
 					// Should we add an icon
-					// icon = SMW.Is part of series; iconfile = SMW.Has icon
+					// icon = SMW.Is part of series or LPDB.series
+					// iconfile = SMW.Has icon or LPDB.icon
 					if ( array_key_exists( 'icon', $tournament ) ) {
 						$iconTitle = Title::newFromText(
 								$iconTemplatePrefix . '/' . $tournament[ 'icon' ],
@@ -109,7 +110,8 @@ class ParserFunction {
 							$parserOptions->setOption( 'enableLimitReport', false );
 							$iconHTML = $parser->parse(
 									'{{' . $iconTemplatePrefix . '/mainpageTST|' .
-									$tournament[ 'iconfile' ] . '|link=}}',
+									'iconDark=' . $tournament[ 'icondarkfile' ] .
+									'|' . $tournament[ 'iconfile' ] . '|link=}}',
 									$parser->getTitle(),
 									$parserOptions,
 									false,


### PR DESCRIPTION
Add support for icondarkfile for TournamentMenu

iirc when concating nil with a string in php nil will be automatically converted to empty string
if not a catch for `$tournament[ 'icondarkfile' ]` being nil would have to be added
