### PR TITLE
Switch from `Template:LeagueIconSmall/mainpageTST` to `Template:LeagueIconSmall/custom`

### DIFF
--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -64,7 +64,7 @@ class MainHookHandler implements
 									$iconTemplatePrefix . '/' . $tournament[ 'icon' ],
 									NS_TEMPLATE
 							);
-							if ( $iconTitle !== null && $iconTitle->exists() && $skin->getTitle() !== null ) {
+							if ( $skin->getTitle() !== null ) {
 								if ( !$commandLineMode ) {
 									$iconHTML = $out->parseInlineAsInterface(
 										'{{' . $iconTemplatePrefix . '/' . $tournament[ 'icon' ] . '|link=}}',

--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -78,13 +78,13 @@ class MainHookHandler implements
 							}
 						} elseif ( array_key_exists( 'iconfile', $tournament ) ) {
 							$iconfileTitle = Title::newFromText(
-									$iconTemplatePrefix . '/mainpageTST',
+									$iconTemplatePrefix . '/custom',
 									NS_TEMPLATE
 							);
 							if ( $iconfileTitle !== null && $iconfileTitle->exists() && $skin->getTitle() !== null ) {
 								if ( !$commandLineMode ) {
 									$iconHTML = $out->parseInlineAsInterface(
-										'{{' . $iconTemplatePrefix . '/mainpageTST|' .
+										'{{' . $iconTemplatePrefix . '/custom|' .
 										( array_key_exists( 'icondarkfile', $tournament )
 											? 'iconDark=' . $tournament[ 'icondarkfile' ] . '|'
 											: '' ) .

--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -64,7 +64,7 @@ class MainHookHandler implements
 									$iconTemplatePrefix . '/' . $tournament[ 'icon' ],
 									NS_TEMPLATE
 							);
-							if ( $skin->getTitle() !== null ) {
+							if ( $iconTitle !== null && $iconTitle->exists() && $skin->getTitle() !== null ) {
 								if ( !$commandLineMode ) {
 									$iconHTML = $out->parseInlineAsInterface(
 										'{{' . $iconTemplatePrefix . '/' . $tournament[ 'icon' ] . '|link=}}',
@@ -81,7 +81,7 @@ class MainHookHandler implements
 									$iconTemplatePrefix . '/custom',
 									NS_TEMPLATE
 							);
-							if ( $iconfileTitle !== null && $iconfileTitle->exists() && $skin->getTitle() !== null ) {
+							if ( $skin->getTitle() !== null ) {
 								if ( !$commandLineMode ) {
 									$iconHTML = $out->parseInlineAsInterface(
 										'{{' . $iconTemplatePrefix . '/custom|' .

--- a/src/ParserFunction.php
+++ b/src/ParserFunction.php
@@ -92,7 +92,7 @@ class ParserFunction {
 						}
 					} elseif ( array_key_exists( 'iconfile', $tournament ) ) {
 						$iconfileTitle = Title::newFromText(
-								$iconTemplatePrefix . '/mainpageTST',
+								$iconTemplatePrefix . '/custom',
 								NS_TEMPLATE
 						);
 						if (
@@ -105,7 +105,7 @@ class ParserFunction {
 							$wasParserReportEnabled = $parserOptions->getOption( 'enableLimitReport' );
 							$parserOptions->setOption( 'enableLimitReport', false );
 							$iconHTML = $parser->parse(
-								'{{' . $iconTemplatePrefix . '/mainpageTST|' .
+								'{{' . $iconTemplatePrefix . '/custom|' .
 								( array_key_exists( 'icondarkfile', $tournament )
 									? 'iconDark=' . $tournament[ 'icondarkfile' ] . '|'
 									: '' ) .


### PR DESCRIPTION
`Template:LeagueIconSmall/custom` exists on commons and hence is available for all wikis, hence this removes the need for wikis to create `Template:LeagueIconSmall/mainpageTST` if they want to switch from using LIS to using the icons from the LPDB data.

Potential follow up: Adjust `Module:TournamentsSummaryTable` to always (on all wikis) use the icon data from LPDB instead of LIS.